### PR TITLE
Corrected bugs and additional functions

### DIFF
--- a/pert/__init__.py
+++ b/pert/__init__.py
@@ -1,3 +1,3 @@
 from .pert import PERT
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/pert/pert.py
+++ b/pert/pert.py
@@ -124,7 +124,7 @@ class PERT:
         Parameters
         ----------
         val: numeric or numeric-array
-            Values to return the PDF calcualtion on
+            Values to return the PDF calculation on
         
         Returns
         -------
@@ -142,7 +142,7 @@ class PERT:
         Parameters
         ----------
         val: numeric or numeric-array
-            Values to return the log-PDF calcualtion on
+            Values to return the log-PDF calculation on
         
         Returns
         -------
@@ -159,7 +159,7 @@ class PERT:
         Parameters
         ----------
         val: numeric or numeric-array
-            Values to return the CDF calcualtion on
+            Values to return the CDF calculation on
         
         Returns
         -------
@@ -171,13 +171,30 @@ class PERT:
         cdf_val = beta_dist.cdf(x, self.alpha, self.beta) / self.range
         return cdf_val
     
-    def logcdf(self, val) -> Array:
+    def ppf(self, val) -> Array:
+        """ Calculates the inverse CDF for a set of inputs
+        
+        Parameters
+        ----------
+        val: numeric or numeric-array
+            Values to return the inverse CDF calculation on
+        
+        Returns
+        -------
+        Array:
+            CDF values based on the val parameter
+        """
+        
+        ppf_val = beta_dist.ppf(val, self.alpha, self.beta) * self.range + self.min_val
+        return ppf_val
+        
+def logcdf(self, val) -> Array:
         """ Calculates the log-CDF value for a set of inputs
         
         Parameters
         ----------
         val: numeric or numeric-array
-            Values to return the log-CDF calcualtion on
+            Values to return the log-CDF calculation on
         
         Returns
         -------

--- a/pert/pert.py
+++ b/pert/pert.py
@@ -188,7 +188,7 @@ class PERT:
         ppf_val = beta_dist.ppf(val, self.alpha, self.beta) * self.range + self.min_val
         return ppf_val
         
-def logcdf(self, val) -> Array:
+    def logcdf(self, val) -> Array:
         """ Calculates the log-CDF value for a set of inputs
         
         Parameters

--- a/pert/pert.py
+++ b/pert/pert.py
@@ -50,14 +50,23 @@ class PERT:
     """
     
     def __init__(self, min_val:Array, ml_val:Array, max_val:Array, lamb=4.0):
-        if lamb <= 0:
-            raise ValueError('lamb parameter should be greater than 0.')
         
         self.a = np.asarray(min_val)
         self.b = np.asarray(ml_val)
         self.c = np.asarray(max_val)
         self.lamb = lamb
         
+        if np.any(lamb <= 0):
+            raise ValueError('lamb parameter should be greater than 0.')
+        if np.any(self.b < self.a):
+            raise ValueError('min_val parameter should be lower than ml_val.')
+        if np.any(self.c < self.b):
+            raise ValueError('ml_val parameter should be lower than max_val.')
+        # in case any a == b == c. Deals with arrays and floating error
+        if np.any(np.multiply(np.isclose(self.a, self.b), 
+                              np.isclose(self.b, self.c))):
+            raise ValueError('min_val, ml_val and max_val parameter should be different.')
+
         self.build()
         
     def build(self):
@@ -98,6 +107,18 @@ class PERT:
             Array of range values of max-min.
         """
         return np.asarray(self.c - self.a)
+    
+    def median(self):
+        """ Calculates the median
+        
+        Returns
+        -------
+        Array:
+            Array of median values.
+        """
+        median = (beta_dist(self.alpha, self.beta).median() * self.range) + self.a
+        return median
+
     
     def rvs(self, size=1, random_state=None):
         """ Returns a randompy-sampled value from the PERT
@@ -168,16 +189,52 @@ class PERT:
         """
         
         x = ((val - self.a) / self.range).clip(0,1)
-        cdf_val = beta_dist.cdf(x, self.alpha, self.beta) / self.range
+        cdf_val = beta_dist.cdf(x, self.alpha, self.beta)
         return cdf_val
     
+    def sf(self, val) -> Array:
+        """ Calculates the survival function for a set of inputs
+        
+        Parameters
+        ----------
+        val: numeric or numeric-array
+            Values to return the survival function calculation on
+        
+        Returns
+        -------
+        Array:
+            survival function based on the val parameter
+        """
+        
+        x = ((val - self.a) / self.range).clip(0,1)
+        sf_val = beta_dist.sf(x, self.alpha, self.beta)
+        return sf_val
+
+    def logsf(self, val) -> Array:
+        """ Calculates the log of the survival function for a set of inputs
+        
+        Parameters
+        ----------
+        val: numeric or numeric-array
+            Values to return the log of the survival calculation on
+        
+        Returns
+        -------
+        Array:
+            log of the survival function based on the val parameter
+        """
+        
+        x = ((val - self.a) / self.range).clip(0,1)
+        logsf_val = beta_dist.logsf(x, self.alpha, self.beta)
+        return logsf_val
+
     def ppf(self, val) -> Array:
         """ Calculates the inverse CDF for a set of inputs
         
         Parameters
         ----------
         val: numeric or numeric-array
-            Values to return the inverse CDF calculation on
+            Values to return the inverse CDF calculation on the val parameter
         
         Returns
         -------
@@ -185,9 +242,25 @@ class PERT:
             CDF values based on the val parameter
         """
         
-        ppf_val = beta_dist.ppf(val, self.alpha, self.beta) * self.range + self.min_val
+        ppf_val = beta_dist.ppf(val, self.alpha, self.beta) * self.range + self.a
         return ppf_val
         
+    def isf(self, val) -> Array:
+        """ Calculates the inverse survival function for a set of inputs
+        
+        Parameters
+        ----------
+        val: numeric or numeric-array
+            Values to return the inverse survival function calculation onthe val parameter
+        
+        Returns
+        -------
+        Array:
+            inverse of the survival function values based on the val parameter
+        """
+        isf_val = beta_dist.isf(val, self.alpha, self.beta) * self.range + self.a
+        return isf_val
+
     def logcdf(self, val) -> Array:
         """ Calculates the log-CDF value for a set of inputs
         


### PR DESCRIPTION
Hi Jason,
I needed to work with Pert distributions in Python and I found your module. Thank you very much for that.

I found two small bugs, though: 
1. The cdf is wrong. 
`import pert`
`oldPert = pert.PERT(10, 150, 200)`
`oldPert.cdf((0,10,200,210)) `
Should lead to 
`array([0., 0., 1., 1.])`
while it leads to 
`array([0.        , 0.        , 0.00526316, 0.00526316])`

2. The absence of checks of the parameters could lead to errors:
`oldPert = pert.PERT(min_val=10,ml_val=10,max_val=3)`
`oldPert.rvs(2)`
lead to values while it should lead to an error because the maximum value is lower than the minimum values. 

I corrected these bugs in the proposed pull request.

Additionally, I implemented new functions:
ppf: the inverse of the cumulative function. (I needed this function for latin hypercube sampling)
median : (as a function. see below) note that it uses the "numerical" evaluation from the beta.median function and not the approximation [(a+6b+c)/8 for lamb=4]. I don't know which one is better
sf : the survival function (1-cdf)
logsf : its logarithm
isf : the inverse of the survival function 

Also, 
I noticed your module is not always in line with "scypi.stats" distribution standard: for example, mean and var should be functions and not attribute, the module works only  on frozen distributions ( PERT(a,b,c).rvs(size=n) works, but not PERT.rvs(size=n,a,b,c). I didn't change this because of probable issues of back compatibility that some users might have faced. Let me know if you think it should be implemented

Please triple check (I am not a fluent Python writer) before integrating those changes if you find them interesting.
Best
