### PR TITLE
hotfix: configure git identity for release tag creation

### DIFF
--- a/.github/workflows/deploy-on-main-merge.yml
+++ b/.github/workflows/deploy-on-main-merge.yml
@@ -143,6 +143,8 @@ jobs:
           SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --tags --force
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
             EXISTING_SHA="$(git rev-list -n 1 "$TAG")"


### PR DESCRIPTION
## Summary
- configure git identity in release tag job before creating annotated tags
- fixes Release On Main Merge failures caused by missing committer identity on GitHub runners

## Why
The release workflow uses `git tag -a`, which requires `user.name` and `user.email`. Without these, tag creation fails with an identity error.

## Scope
- workflow-only change
- no package code changes
