### PR TITLE
ci: automate post-release main-to-dev sync PR flow

### DIFF
--- a/.github/workflows/deploy-on-main-merge.yml
+++ b/.github/workflows/deploy-on-main-merge.yml
@@ -305,3 +305,88 @@ jobs:
             echo "- If tag/release metadata is incorrect, correct or remove tag: \`git push origin :refs/tags/$TAG\`."
             echo "- Publish a corrective hotfix release."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  sync-main-into-dev:
+    needs:
+      - post-release-verification
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Create or update main->dev sync PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const marker = "<!-- auto-main-to-dev-sync -->";
+            const title = "chore: sync main into dev after release merge";
+            const body = [
+              marker,
+              "Automated sync PR from `main` to `dev` after successful release workflow completion.",
+              "",
+              "This PR was created by workflow `deploy-on-main-merge.yml`.",
+            ].join("\n");
+
+            const existing = await github.paginate(
+              github.rest.pulls.list,
+              {
+                owner,
+                repo,
+                state: "open",
+                head: `${owner}:main`,
+                base: "dev",
+                per_page: 100,
+              },
+            );
+
+            let pr;
+            if (existing.length > 0) {
+              pr = existing[0];
+              core.info(`Found existing sync PR: ${pr.html_url}`);
+            } else {
+              try {
+                const created = await github.rest.pulls.create({
+                  owner,
+                  repo,
+                  title,
+                  head: "main",
+                  base: "dev",
+                  body,
+                  draft: false,
+                });
+                pr = created.data;
+                core.info(`Created sync PR: ${pr.html_url}`);
+              } catch (error) {
+                const message = String(error?.message || error);
+                if (message.includes("No commits between")) {
+                  core.info("No sync PR needed: main and dev are already aligned.");
+                  return;
+                }
+                throw error;
+              }
+            }
+
+            try {
+              await github.graphql(
+                `mutation($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId,
+                    mergeMethod: MERGE
+                  }) {
+                    pullRequest {
+                      number
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }`,
+                { pullRequestId: pr.node_id },
+              );
+              core.info(`Enabled auto-merge for PR #${pr.number}.`);
+            } catch (error) {
+              core.warning(
+                `Unable to enable auto-merge for PR #${pr.number}: ${String(error?.message || error)}`,
+              );
+            }

--- a/.github/workflows/gitflow-pr-rules.yml
+++ b/.github/workflows/gitflow-pr-rules.yml
@@ -22,7 +22,7 @@ jobs:
           allowed=false
 
           if [[ "$BASE_REF" == "dev" ]]; then
-            if [[ "$HEAD_REF" == feature/* ]]; then
+            if [[ "$HEAD_REF" == feature/* || "$HEAD_REF" == "main" ]]; then
               allowed=true
             fi
           elif [[ "$BASE_REF" == "main" ]]; then
@@ -35,6 +35,7 @@ jobs:
             echo "Invalid GitFlow PR path: '$HEAD_REF' -> '$BASE_REF'"
             echo "Allowed paths:"
             echo "  feature/* -> dev"
+            echo "  main -> dev"
             echo "  release/* -> main"
             echo "  hotfix/* -> main"
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,11 @@ These instructions apply to the entire repo tree.
   - `feature/*`: branch from `dev`, merge back into `dev`.
   - `release/*`: branch from `dev`, merge into `main` only.
   - `hotfix/*`: branch from `main`, merge into `main` only.
+  - `main -> dev`: permitted for post-release synchronization via pull request.
 - Contribution scope:
   - Community contributors are welcome to propose changes through `feature/* -> dev` pull requests.
   - `release/*` and `hotfix/*` branches and pull requests are core-developer managed.
+  - `main -> dev` synchronization pull requests are core-developer managed.
 - Never commit directly to `main` or `dev`.
 - Use pull requests for all merges.
 - Create pull requests as draft PRs by default; this is a recommended default, not a mandatory enforcement. Developers may open regular/open PRs when they judge it appropriate.
@@ -66,8 +68,13 @@ These instructions apply to the entire repo tree.
 - Treat declarative requirement statements (for example: "it should...", "the action should...", "this needs to...") as non-executable unless accompanied by a separate explicit execution cue.
 - Require a separate explicit execution cue (for example: "implement this", "go ahead and make this change") before making changes after proposal/question discussion.
 - For question-form prompts, do not execute edits or commands even if a task is described; require a follow-up explicit execution cue in a separate interaction.
-- Before executing any change after proposal/question discussion, send a preflight confirmation message: "Execution confirmation required. No changes made yet."
-- After an explicit execution cue is received, execute without requesting another confirmation unless requirements changed materially or became ambiguous.
+- Before executing any change after proposal/question discussion, send one preflight confirmation message: "Execution confirmation required. No changes made yet."
+- After an explicit execution cue is received, execute without requesting another confirmation.
+- Do not repeat preflight confirmation for subsequent actions within the same confirmed scope.
+- Request confirmation again only if requirements changed materially, scope expanded beyond what was confirmed, or instructions became ambiguous.
+- If the request names a specific operation, execute only that operation and nothing else unless the user explicitly authorizes additional operations.
+- Do not chain inferred follow-up steps beyond the explicitly requested operation(s).
+- After completing the explicitly requested operation(s), stop and return control to the user; wait for the next instruction before taking further actions.
 - If a user message mixes question framing with an implied task, treat it as non-executable until explicit confirmation is received.
 - If intent is ambiguous, ask a short confirmation question before making changes.
 - If a request is ambiguous, ask a clarifying question before taking any action.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ This project uses GitFlow and PR-based development. See [`AGENTS.md`](AGENTS.md)
 ## Contribution Scope
 - Community contributors are welcome to propose changes through `feature/* -> dev` pull requests.
 - `release/* -> main` and `hotfix/* -> main` branches/pull requests are core-developer managed.
+- `main -> dev` synchronization pull requests are core-developer managed.
 
 ## Development Setup
 Install development dependencies:
@@ -26,6 +27,8 @@ uv run pytest -q
 - Releases and hotfixes are managed by core developers:
   - `release/<semver> -> main`
   - `hotfix/<semver> -> main`
+- Post-release synchronization is core-managed:
+  - `main -> dev`
 
 ## Versioning and Release Notes
 - Follow Semantic Versioning (`MAJOR.MINOR.PATCH`).

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ See [`VersionHistory.md`](VersionHistory.md).
 
 ## Repository Policy
 High-level development policy summary (full details in [`AGENTS.md`](AGENTS.md)):
-- GitFlow is used: `feature/* -> dev`, `release/*|hotfix/* -> main`, with PR-based merges.
-- Community contributions are welcome through `feature/* -> dev` pull requests; `release/*` and `hotfix/*` flows are core-developer managed.
+- GitFlow is used: `feature/* -> dev`, `release/*|hotfix/* -> main`, and `main -> dev` sync PRs, with PR-based merges.
+- Community contributions are welcome through `feature/* -> dev` pull requests; `release/*`, `hotfix/*`, and `main -> dev` sync flows are core-developer managed.
 - CI runs on PRs to `dev` and `main`; release dry-runs run on `release/*`/`hotfix/*` PRs to `main`; release publish runs after merge to `main`.
 - Semantic Versioning is required (`MAJOR.MINOR.PATCH`) and versioning must be intentional.
 - Some defaults are guidance (for example draft PR by default) and developer discretion is explicitly supported.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ See [`VersionHistory.md`](VersionHistory.md).
 - Community and core-developer contribution workflow is documented in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 - Repository guardrails and policy details are defined in [`AGENTS.md`](AGENTS.md).
 
+## AI Usage
+In this repository, AI tooling is used to assist with non-functional development work, including test authoring, documentation drafting/editing, GitHub Actions/workflow authoring and maintenance, and planning/decision support.
+
+Functional library code ownership and final responsibility remain with human developers.
+
 ## Release Process (High-Level)
 - Pull requests from `release/*` and `hotfix/*` into `main` run publish dry-run checks.
 - Merged `release/*` / `hotfix/*` PRs to `main` trigger publish, tagging, release metadata, and post-release verification workflows.


### PR DESCRIPTION
## Summary
- add automated main -> dev synchronization after successful release/hotfix merges to main
- update GitFlow PR validation to permit main -> dev sync PRs
- align AGENTS.md, CONTRIBUTING.md, and README policy language with the new sync flow

## Notes
- this is intended as core-maintainer automation for post-release branch synchronization